### PR TITLE
Added default actions

### DIFF
--- a/eox_hooks/actions.py
+++ b/eox_hooks/actions.py
@@ -1,0 +1,17 @@
+"""This module defines generic actions for defined hooks."""
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def default_action(**kwargs):
+    """
+    Default action called when:
+    - The signal handler receives a signal that is not defined.
+    - The module/action defined in the configurations does not exist.
+    - The current tenant does not have the correct settings.
+    """
+    sender = kwargs.pop("sender")
+
+    log.info("This logging action was triggered by {} with the following arguments: {}"
+             .format(sender, str(kwargs)))

--- a/eox_hooks/actions_handler.py
+++ b/eox_hooks/actions_handler.py
@@ -2,7 +2,7 @@
 import logging
 from importlib import import_module
 
-from eox_hooks.tests.test_utils import custom_action_mock
+from eox_hooks.actions import default_action
 
 log = logging.getLogger(__name__)
 
@@ -50,4 +50,4 @@ def action_lookup(module_name, action):
                     )
 
     log.warning(message)
-    return custom_action_mock
+    return default_action

--- a/eox_hooks/tests/test_actions.py
+++ b/eox_hooks/tests/test_actions.py
@@ -1,0 +1,30 @@
+"""This file contains all the test for the tasks.py file.
+Classes:
+    SingalsTestCase: Test tasks.
+"""
+from django.test import TestCase
+from testfixtures import LogCapture
+
+from eox_hooks.actions import default_action
+
+
+class TestActionss(TestCase):
+    """Tasks test class."""
+
+    def setUp(self):
+        self.kwargs = {
+            "course_id": "course_id",
+            "username": "username",
+        }
+        self.sender = "sender.example"
+
+    def test_default_action(self):
+        """Used to test the correct execution of the default action."""
+        message = "This logging action was triggered by sender.example with the following arguments: {}" \
+                  .format(str(self.kwargs))
+
+        with LogCapture() as log:
+            default_action(sender=self.sender, **self.kwargs)
+            log.check(("eox_hooks.actions",
+                       "INFO",
+                       message))

--- a/eox_hooks/tests/test_actions_handler.py
+++ b/eox_hooks/tests/test_actions_handler.py
@@ -17,8 +17,8 @@ class TestActionHandler(TestCase):
         """Set up class for ActionHandler testing."""
         self.trigger_event = "trigger_event"
         self.configuration = {
-            "module": "eox_hooks.tests.test_utils",
-            "action": "custom_action_mock",
+            "module": "eox_hooks.actions",
+            "action": "default_action",
             "fail_silently": True,
         }
 
@@ -56,8 +56,8 @@ class TestActionHandler(TestCase):
         action_mock.side_effect = Exception()
         action_lookup_mock.return_value = action_mock
         configuration = {
-            "module": "eox_hooks.tests.test_utils",
-            "action": "custom_action_mock",
+            "module": "eox_hooks.actions",
+            "action": "default_action",
             "fail_silently": False,
         }
 
@@ -68,19 +68,19 @@ class TestActionHandler(TestCase):
 class TestActionLookup(TestCase):
     """ActionLookup test class."""
 
-    @patch("eox_hooks.tests.test_utils.custom_action_mock")
-    def test_return_specified_action(self, custom_action_mock):
+    @patch("eox_hooks.actions.default_action")
+    def test_return_specified_action(self, default_action):
         """Used to verify the successful lookup of an existent task."""
-        module_name, action = "eox_hooks.tests.test_utils", "custom_action_mock"
+        module_name, action = "eox_hooks.actions", "default_action"
 
         action = action_lookup(module_name, action)
 
-        self.assertEqual(action, custom_action_mock)
+        self.assertEqual(action, default_action)
 
-    @patch("eox_hooks.actions_handler.custom_action_mock")
-    def test_with_non_existent_action(self, custom_action_mock):
+    @patch("eox_hooks.actions_handler.default_action")
+    def test_with_non_existent_action(self, default_action):
         """Used to test what happends if a non-existent action is passed."""
-        module_name, action = "eox_hooks.tests.test_utils", "non_existent_action"
+        module_name, action = "eox_hooks.actions_handler", "non_existent_action"
         log_message = "The action {} does not exist in the module {}. A default action will be used."\
                       .format(
                             action,
@@ -93,12 +93,12 @@ class TestActionLookup(TestCase):
                        "WARNING",
                        log_message))
 
-        self.assertEqual(action, custom_action_mock)
+        self.assertEqual(action, default_action)
 
-    @patch("eox_hooks.actions_handler.custom_action_mock")
-    def test_with_non_existent_module(self, custom_action_mock):
+    @patch("eox_hooks.actions_handler.default_action")
+    def test_with_non_existent_module(self, default_action):
         """Used to test what happends if a non-existent module is passed."""
-        module_name, action = "non_existent_module", "custom_action_mock"
+        module_name, action = "non_existent_module", "default_action"
         log_message = "The module {} with the action {} does not exist. A default action will be used."\
                       .format(
                           module_name,
@@ -111,4 +111,4 @@ class TestActionLookup(TestCase):
                        "WARNING",
                        log_message))
 
-        self.assertEqual(action, custom_action_mock)
+        self.assertEqual(action, default_action)

--- a/eox_hooks/tests/test_receivers.py
+++ b/eox_hooks/tests/test_receivers.py
@@ -58,8 +58,8 @@ class TestReceivers(TestCase):
         action_handler.assert_not_called()
 
     @override_settings(EOX_HOOKS_DEFINITIONS={})
-    @patch("eox_hooks.actions_handler.custom_action_mock")
-    def test_without_hooks_configuration_defined(self, custom_action_mock):
+    @patch("eox_hooks.actions_handler.default_action")
+    def test_without_hooks_configuration_defined(self, default_action):
         """
         Used to test what happends if the current tenant is using eox-hooks but there is not a
         configuration defined.
@@ -68,4 +68,4 @@ class TestReceivers(TestCase):
         """
         hooks_handler(self.sender, self.signal)
 
-        custom_action_mock.assert_not_called()
+        default_action.assert_not_called()

--- a/eox_hooks/tests/test_utils.py
+++ b/eox_hooks/tests/test_utils.py
@@ -1,7 +1,0 @@
-"""
-Test utils functions.
-"""
-
-
-def custom_action_mock(**kwargs):  # pylint: disable=unused-argument
-    """Function used to test custom signal receiver."""


### PR DESCRIPTION
This PR adds a logging action that works as a default action. This action is used in the following scenarios:

- The signal handler receives a signal that is not defined: this means that if the handler receives a signal that is not defined in the plugin configurations, then the default action will be triggered.
- The module/action defined in the configurations does not exist: if an action that does not exist is set in the configurations, then the default action will be triggered.
- The current tenant does not have the correct settings: if the tenant uses eox-hooks but it does not have the correct EOX_HOOKS_CONFIGURATIONS (for example: is empty), then the default action will be triggered.

