### PR TITLE
Fix install issue when signal_path does not exist

### DIFF
--- a/eox_hooks/__init__.py
+++ b/eox_hooks/__init__.py
@@ -4,4 +4,9 @@ Init module for eox_hooks.
 
 from __future__ import unicode_literals
 
+import django.dispatch
+
 __version__ = '0.2.0'
+
+
+dummy_signal = django.dispatch.Signal()

--- a/eox_hooks/actions_handler.py
+++ b/eox_hooks/actions_handler.py
@@ -20,9 +20,9 @@ def action_handler(trigger_event, configuration, **kwargs):
     action_result = None
     try:
         action_result = action(**kwargs)
-        log.info("The action {} with triggered by {} ended successfully.".format(action, trigger_event))
+        log.info("The action {} triggered by {} ended successfully.".format(action, trigger_event))
     except Exception as exception:  # pylint: disable=broad-except
-        log.error("The action {} with triggered by {} failed.".format(action, trigger_event))
+        log.error("The action {} triggered by {} failed.".format(action, trigger_event))
 
         if not configuration.get("fail_silently"):
             raise exception

--- a/eox_hooks/apps.py
+++ b/eox_hooks/apps.py
@@ -4,7 +4,30 @@ App configuration for eox_hooks.
 
 from __future__ import unicode_literals
 
+from importlib import import_module
+
 from django.apps import AppConfig
+
+OPENEDX_HOOKS_TRIGGER_MODULE = "openedx.core.lib.triggers.v1"
+EOX_HOOKS_DEFAULT_TRIGGER = "eox_hooks.dummy_signal"
+
+
+def get_signal_module(signal_name):
+    """
+    Function that checks whether a module with `signal_name` exists, if it doesn't then
+    a default signal module is returned.
+    """
+    try:
+        trigger_signal = "{signals_module}.{signal_name}".format(
+            signals_module=OPENEDX_HOOKS_TRIGGER_MODULE,
+            signal_name=signal_name,
+        )
+        module = import_module(OPENEDX_HOOKS_TRIGGER_MODULE)
+        getattr(module, signal_name)
+    except (ImportError, AttributeError):
+        trigger_signal = EOX_HOOKS_DEFAULT_TRIGGER
+
+    return trigger_signal
 
 
 class EoxHooksConfig(AppConfig):
@@ -45,7 +68,7 @@ class EoxHooksConfig(AppConfig):
                 'receivers': [
                     {
                         'receiver_func_name': 'hooks_handler',
-                        'signal_path': 'openedx.core.lib.triggers.v1.pre_enrollment',
+                        'signal_path': get_signal_module("pre_enrollment"),
                         'dispatch_uid': 'eox-hooks:pre_enrollment',
                     },
                 ],

--- a/eox_hooks/tests/test_actions_handler.py
+++ b/eox_hooks/tests/test_actions_handler.py
@@ -38,8 +38,8 @@ class TestActionHandler(TestCase):
         action_mock = Mock()
         action_lookup_mock.return_value = action_mock
         action_mock.side_effect = Exception()
-        log_message = "The action {} with triggered by {} failed.".format(action_mock,
-                                                                          self.trigger_event)
+        log_message = "The action {} triggered by {} failed.".format(action_mock,
+                                                                     self.trigger_event)
 
         with LogCapture() as log:
             action_handler(self.trigger_event, self.configuration)

--- a/eox_hooks/tests/test_apps.py
+++ b/eox_hooks/tests/test_apps.py
@@ -1,0 +1,34 @@
+"""This file contains all the test for the functions defined in apps.py file.
+
+Classes:
+    TestAppsHelpers.
+"""
+from django.test import TestCase
+from mock import patch
+
+from eox_hooks.apps import get_signal_module
+
+
+class TestAppsHelpers(TestCase):
+    """
+    Class that tests function helpers defined in Apps.
+    """
+
+    @patch("eox_hooks.apps.import_module")
+    def test_get_signal_module_success(self, _):
+        """Used to test getting the signal module of an existent signal."""
+        signal_module = get_signal_module("defined_signal")
+
+        self.assertEqual("openedx.core.lib.triggers.v1.defined_signal", signal_module)
+
+    @patch("eox_hooks.apps.import_module")
+    def test_get_signal_module_fail(self, import_mock):
+        """
+        Used to test getting the signal module of a non-existent module, this should return the
+        default module.
+        """
+        import_mock.side_effect = ImportError
+
+        signal_module = get_signal_module("undefined_signal")
+
+        self.assertEqual("eox_hooks.dummy_signal", signal_module)


### PR DESCRIPTION
This PR fixes the following error that raises after installing eox-hooks:

![preview-lightbox-image](https://user-images.githubusercontent.com/64440265/97050036-aaaa9000-154a-11eb-9755-74f9566bb9ce.png)

This happens when in `EoxHooksConfig.plugin_app` we define a nonexistent `signal_path`

Now, if the `signal_path` does not exist then a default path is used.