### PR TITLE
Add post_register signal configuration

### DIFF
--- a/eox_hooks/apps.py
+++ b/eox_hooks/apps.py
@@ -76,6 +76,11 @@ class EoxHooksConfig(AppConfig):
                         'signal_path': get_signal_module("post_certificate_creation"),
                         'dispatch_uid': "eox-hooks:post_certificate_creation",
                     },
+                    {
+                        'receiver_func_name': 'hooks_handler',
+                        'signal_path': get_signal_module("post_register"),
+                        'dispatch_uid': "eox-hooks:post_register",
+                    },
                 ],
             }
         },


### PR DESCRIPTION
This PR adds the post_register signal configuration, needed for the [UPC EXED post register Hook](https://3.basecamp.com/3966315/buckets/8050706/todos/3607953105#__recording_3636632623)

PR that adds the post register trigger to the platform https://github.com/eduNEXT/edunext-platform/pull/510