### PR TITLE
feat: register post-enrollment signal

### DIFF
--- a/eox_hooks/apps.py
+++ b/eox_hooks/apps.py
@@ -68,18 +68,23 @@ class EoxHooksConfig(AppConfig):
                 'receivers': [
                     {
                         'receiver_func_name': 'hooks_handler',
-                        'signal_path': get_signal_module("pre_enrollment"),
+                        'signal_path': get_signal_module('pre_enrollment'),
                         'dispatch_uid': 'eox-hooks:pre_enrollment',
                     },
                     {
                         'receiver_func_name': 'hooks_handler',
-                        'signal_path': get_signal_module("post_certificate_creation"),
-                        'dispatch_uid': "eox-hooks:post_certificate_creation",
+                        'signal_path': get_signal_module('post_certificate_creation'),
+                        'dispatch_uid': 'eox-hooks:post_certificate_creation',
                     },
                     {
                         'receiver_func_name': 'hooks_handler',
-                        'signal_path': get_signal_module("post_register"),
-                        'dispatch_uid': "eox-hooks:post_register",
+                        'signal_path': get_signal_module('post_register'),
+                        'dispatch_uid': 'eox-hooks:post_register',
+                    },
+                    {
+                        'receiver_func_name': 'hooks_handler',
+                        'signal_path': get_signal_module('post_enrollment'),
+                        'dispatch_uid': 'eox-hooks:post_enrollment',
                     },
                 ],
             }


### PR DESCRIPTION
**Description**
This PR registers the post-enrollment signal created [here](https://github.com/eduNEXT/edunext-platform/pull/540)

**Supporting information**
https://edunext.atlassian.net/browse/PS2021-916?atlOrigin=eyJpIjoiYmRiZmJiYzk0ZjkxNGJiN2FlYWU3ODU0ZjUwYjY4N2IiLCJwIjoiaiJ9

**Testing instructions**
1. Use this version of eox-hooks
2. Create a custom action in your favorite plugin
3. Add eox-hooks configuration to your site
3. Enroll in a course