### PR TITLE
feat: add action that creates enrollments for course programs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 ----------
 * Drop support for python 2.7.
 * Add backends for course, enrollment and course modes.
+* Add custom action and task used to enroll users into program courses.
 
 [0.5.0] - 2021-04-13
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/eox_hooks/apps.py
+++ b/eox_hooks/apps.py
@@ -89,3 +89,10 @@ class EoxHooksConfig(AppConfig):
             }
         },
     }
+
+    # pylint: disable=import-outside-toplevel
+    def ready(self):
+        """
+        Make sure tasks are registered.
+        """
+        from eox_hooks import tasks  # pylint: disable=unused-import

--- a/eox_hooks/tasks.py
+++ b/eox_hooks/tasks.py
@@ -1,0 +1,68 @@
+"""
+Task file for eox-hooks plugin.
+"""
+import logging
+
+from celery import shared_task
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from eox_hooks.edxapp_wrapper.course_modes import get_all_course_modes
+from eox_hooks.edxapp_wrapper.enrollments import get_course_enrollment
+
+MODES_FOR_COURSE = get_all_course_modes()
+ENROLLMENT_MAX_RETRIES = 3
+User = get_user_model()
+CourseEnrollment = get_course_enrollment()
+log = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=ENROLLMENT_MAX_RETRIES)
+def create_enrollments_for_program(self, username, followup_enrollments):
+    """
+    Create enrollments for a list of courses that define a Course Program.
+
+    Args:
+        username (str): identification of the user to be enrolled.
+        mode (str): CourseMode for the enrollment.
+        followup_enrollments ([Dict]): list of values used in the enrollment
+        creation. The valid attributes are:
+            - course_id
+            - mode
+    """
+    try:
+        user = User.objects.get(username=username)
+
+        for enrollment in followup_enrollments:
+
+            course_key_str = enrollment.pop("course_id", "")
+
+            try:
+                course_key = CourseKey.from_string(course_key_str)
+            except InvalidKeyError:
+                log.error(
+                    "Couldn't create enrollment for course because the configuration is not valid: "
+                    "course ID missing or invalid."
+                )
+                continue
+
+            mode = enrollment.get("mode", "audit")
+            mode_not_valid = mode.lower() not in MODES_FOR_COURSE
+            course_org_not_valid = course_key.org not in getattr(
+                settings, "course_org_filter", []
+            )
+
+            if mode_not_valid or course_org_not_valid:
+                log.error(
+                    "Couldn't create enrollment for %s because the configuration is not valid: "
+                    "invalid organization or course mode.",
+                    course_key_str,
+                )
+                continue
+
+            CourseEnrollment.enroll(user, course_key, mode)
+
+    except Exception as e:
+        raise self.retry(exc=e)

--- a/eox_hooks/tests/test_actions.py
+++ b/eox_hooks/tests/test_actions.py
@@ -2,11 +2,14 @@
 
 Classes:
     TestPostToWebhookUrl.
+    TriggerEnrollmentsTest.
 """
+from unittest.mock import MagicMock, patch
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from eox_hooks.actions import get_request_fields
+from eox_hooks.actions import get_request_fields, trigger_enrollments_creation
 
 
 class TestPostToWebhookUrl(TestCase):
@@ -73,3 +76,89 @@ class TestPostToWebhookUrl(TestCase):
         result_data = get_request_fields(fields, extra_fields, **self.kwargs)
 
         self.assertEqual(expected_data, result_data)
+
+
+class TriggerEnrollmentsTest(TestCase):
+    """
+    Test class for trigger enrollment creation for program.
+    """
+
+    create_enrollments_for_program = patch("eox_hooks.actions.create_enrollments_for_program")
+    get_course = patch("eox_hooks.actions._get_course")
+
+    def setUp(self):
+        """
+        Setup common conditions for test cases.
+        """
+        self.user = MagicMock(username="test")
+        self.kwargs = {
+            "user": self.user,
+        }
+
+    @create_enrollments_for_program
+    @get_course
+    def test_course_without_settings(self, get_course, create_enroll_task):
+        """
+        Tests action when the user enrolls into a course without other_course_settings.
+        This is a version of a course not configured as program.
+
+        Expected behavior:
+            - Action returns without creating other enrollments.
+        """
+        mock_course = MagicMock()
+        del mock_course.other_course_settings
+        get_course.return_value = mock_course
+
+        trigger_enrollments_creation(**self.kwargs)
+
+        create_enroll_task.delay.assert_not_called()
+
+    @create_enrollments_for_program
+    @get_course
+    def test_enroll_into_regular_course(self, get_course, create_enroll_task):
+        """
+        Tests action when the user enrolls into a regular course. Meaning, a course
+        not configured with EDNX_TRIGGER_FOLLOWUP_ENROLLMENTS.
+
+        Expected behavior:
+            - Action returns without creating other enrollments.
+        """
+        other_course_settings = {
+            "course_setting": "setting_value",
+        }
+        mock_course = MagicMock(other_course_settings=other_course_settings)
+        get_course.return_value = mock_course
+
+        trigger_enrollments_creation(**self.kwargs)
+
+        create_enroll_task.delay.assert_not_called()
+
+    @create_enrollments_for_program
+    @get_course
+    def test_enroll_for_program(self, get_course, create_enroll_task):
+        """
+        Tests action when the user enrolls into a Course Program.
+
+        Expected behavior:
+            - Action starts an async task that creates the other enrollments.
+        """
+        other_course_settings = {
+            "EDNX_TRIGGER_FOLLOWUP_ENROLLMENTS": [
+                {
+                    "course_id": "course-v1:edX+DemoX+Demo_Course",
+                },
+            ],
+        }
+        mock_course = MagicMock(other_course_settings=other_course_settings)
+        get_course.return_value = mock_course
+
+        trigger_enrollments_creation(**self.kwargs)
+
+        create_enroll_task.delay.assert_called_once_with(
+            "test",
+            [
+                {
+                    "course_id": "course-v1:edX+DemoX+Demo_Course",
+                },
+            ],
+        )

--- a/eox_hooks/tests/test_tasks.py
+++ b/eox_hooks/tests/test_tasks.py
@@ -1,0 +1,114 @@
+"""
+This file contains all the test for the tasks.py file.
+
+Classes:
+    EnrollmentCreationTest.
+"""
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from opaque_keys.edx.keys import CourseKey
+
+from eox_hooks.tasks import create_enrollments_for_program
+
+
+class EnrollmentCreationTest(TestCase):
+    """
+    Test class for trigger enrollment creation for program.
+    """
+
+    get_enrollment = patch("eox_hooks.tasks.CourseEnrollment")
+
+    def setUp(self):
+        """
+        Setup common conditions for test cases.
+        """
+        self.user = User.objects.create_user(username="test")
+        self.invalid_followup_enrollments = [
+            {
+                "course_id": "course-v1:edx+DemoX+Demo_Course",
+                "mode": "premium"
+            },
+        ]
+        self.valid_followup_enrollments = [
+            {
+                "course_id": "course-v1:Demo+DemoX+Demo_Course",
+                "mode": "honor"
+            },
+        ]
+        self.course = Mock(id="course-v1:Demo+DemoX+Demo_Course", org="Demo")
+        self.course_key = CourseKey.from_string(self.course.id)
+
+    @get_enrollment
+    def test_enrollment_mode_invalid(self, course_enrollment):
+        """
+        Tests enrollment creation when the configuration is invalid.
+
+        Expected behavior:
+            - Followup enrollment is not created.
+        """
+        with self.assertLogs('eox_hooks.tasks', 'ERROR'):
+            create_enrollments_for_program(  # pylint: disable=no-value-for-parameter
+                username=self.user.username,
+                followup_enrollments=self.invalid_followup_enrollments,
+            )
+        course_enrollment.enroll.assert_not_called()
+
+    @override_settings(course_org_filter=["edx"])
+    @get_enrollment
+    def test_enrollment_org_invalid(self, course_enrollment):
+        """
+        Tests enrollment creation when the configuration is invalid.
+
+        Expected behavior:
+            - Followup enrollment is not created.
+        """
+        with self.assertLogs('eox_hooks.tasks', 'ERROR'):
+            create_enrollments_for_program(  # pylint: disable=no-value-for-parameter
+                username=self.user.username,
+                followup_enrollments=self.invalid_followup_enrollments,
+            )
+        course_enrollment.enroll.assert_not_called()
+
+    @get_enrollment
+    def test_enrollment_key_invalid(self, course_enrollment):
+        """
+        Tests enrollment creation when the configuration is invalid.
+
+        Expected behavior:
+            - Followup enrollment is not created.
+        """
+        enrollment_config = [
+            {
+                "course_id": "Demo",
+                "mode": "honor"
+            },
+        ]
+
+        with self.assertLogs('eox_hooks.tasks', 'ERROR'):
+            create_enrollments_for_program(  # pylint: disable=no-value-for-parameter
+                username=self.user.username,
+                followup_enrollments=enrollment_config,
+            )
+        course_enrollment.enroll.assert_not_called()
+
+    @override_settings(course_org_filter=["Demo"])
+    @get_enrollment
+    def test_enrollments_for_program(self, course_enrollment):
+        """
+        Tests valid enrollment creation after user's enrollment in a program.
+
+        Expected behavior:
+            - Followup enrollments are created.
+        """
+        create_enrollments_for_program(  # pylint: disable=no-value-for-parameter
+            username=self.user.username,
+            followup_enrollments=self.valid_followup_enrollments,
+        )
+
+        course_enrollment.enroll.assert_called_once_with(
+            self.user,
+            self.course_key,
+            "honor",
+        )

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,3 +3,5 @@
 
 Django
 djangorestframework
+edx-opaque-keys[django]
+celery

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,13 +4,43 @@
 #
 #    make upgrade
 #
+amqp==1.4.9
+    # via kombu
+anyjson==0.3.3
+    # via kombu
+billiard==3.3.0.23
+    # via celery
+celery==3.1.26.post2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django==2.2.24
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   edx-opaque-keys
 djangorestframework==3.9.4
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+edx-opaque-keys[django]==2.1.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+kombu==3.0.37
+    # via celery
+pbr==5.6.0
+    # via stevedore
+pymongo==3.12.0
+    # via edx-opaque-keys
 pytz==2021.1
-    # via django
+    # via
+    #   celery
+    #   django
+six==1.16.0
+    # via
+    #   edx-opaque-keys
+    #   stevedore
 sqlparse==0.4.1
     # via django
+stevedore==1.32.0
+    # via edx-opaque-keys

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,5 +15,7 @@ pylint==2.5.0
 pycodestyle==2.6.0
 
 # Keep same platform version
+celery==3.1.26.post2
 djangorestframework==3.9.4
+edx-opaque-keys[django]==2.1.0
 testfixtures==6.4.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,8 +4,24 @@
 #
 #    make upgrade
 #
+amqp==1.4.9
+    # via
+    #   -r requirements/base.txt
+    #   kombu
+anyjson==0.3.3
+    # via
+    #   -r requirements/base.txt
+    #   kombu
 astroid==2.4.2
     # via pylint
+billiard==3.3.0.23
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==3.1.26.post2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 certifi==2021.5.30
     # via requests
 chardet==4.0.0
@@ -13,8 +29,14 @@ chardet==4.0.0
 coverage==5.5
     # via -r requirements/test.in
 django==2.2.24
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
 djangorestframework==3.9.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+edx-opaque-keys[django]==2.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -22,12 +44,20 @@ idna==2.10
     # via requests
 isort==4.3.21
     # via pylint
+kombu==3.0.37
+    # via
+    #   -r requirements/base.txt
+    #   celery
 lazy-object-proxy==1.4.3
     # via astroid
 mccabe==0.6.1
     # via pylint
 mock==3.0.5
     # via -r requirements/test.in
+pbr==5.6.0
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
 pycodestyle==2.6.0
     # via
     #   -c requirements/constraints.txt
@@ -36,20 +66,32 @@ pylint==2.5.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
+pymongo==3.12.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
 pytz==2021.1
     # via
     #   -r requirements/base.txt
+    #   celery
     #   django
 requests==2.25.1
     # via -r requirements/test.in
 six==1.16.0
     # via
+    #   -r requirements/base.txt
     #   astroid
+    #   edx-opaque-keys
     #   mock
+    #   stevedore
 sqlparse==0.4.1
     # via
     #   -r requirements/base.txt
     #   django
+stevedore==1.32.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
 testfixtures==6.4.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -38,7 +38,7 @@ toml==0.10.2
     # via tox
 tox==3.24.1
     # via -r requirements/tox.in
-virtualenv==20.7.1
+virtualenv==20.7.2
     # via tox
 zipp==1.2.0
     # via


### PR DESCRIPTION
**Description**

This PR adds a new _action_ that can be executed after the user's enrollment in a course, triggered by the [post_enrollment signal](https://github.com/eduNEXT/edunext-platform/pull/540). When executed, enrolls the user in a list of courses defined in the course advanced settings.

**How to test**

_Course configuration_
In your _course advanced settings_*, add:
```
    "EDNX_TRIGGER_FOLLOWUP_ENROLLMENTS": [
        {
            "course_id": "course-v1:Demo+CSTest+2020",  
            "mode": "honor"
        }
    ]  # List of enrollment information used after the main enrollment 
```
To enable course advanced settings, turn on this feature:
cms/envs/common.py
`    'ENABLE_OTHER_COURSE_SETTINGS': True,`

_Microsite configuration_
In your microsite settings:

```
"EOX_HOOKS_DEFINITIONS": {
        "post_enrollment": {
            "action": "trigger_enrollments_creation",
            "fail_silently": false,
            "module": "eox_hooks.actions"
        }
    },
   "USE_EOX_HOOKS": true,
```

**Supporting information**

https://edunext.atlassian.net/browse/PS2021-916?atlOrigin=eyJpIjoiMTFlNTdiN2JmYmVjNDZjMWE2MTk2MjBiNzFjNzMxNTQiLCJwIjoiaiJ9 
