### PR TITLE
feat!: drop support for python 2.7 and django11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,13 @@ workflows:
               only: /v?[0-9]+(\.[0-9]+)*/
           matrix:
             parameters:
-              python_version: ["2.7", "3.5"]
-              django_version: ["django111", "django22"]
+              python_version: ["3.5", "3.8"]
+              debian_version: ["stretch", "buster"]
             exclude:
-              - python_version: "2.7"
-                django_version: "django22"
+              - python_version: "3.8"
+                debian_version: "stretch"
+              - python_version: "3.5"
+                debian_version: "buster"
       - pypi:
           requires:
             - test
@@ -32,6 +34,7 @@ jobs:
     parameters:
       django_version:
         type: string
+        default: django22
       python_version:
         type: string
       debian_version:
@@ -72,6 +75,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
+            export TOX_ENV=$PY_ENV-$DJANGO_ENV
             export TOXENV=${TOX_ENV//./}
             make run-tests
 
@@ -82,7 +86,8 @@ jobs:
           key: v2-<< parameters.python_version >>-<< parameters.django_version >>-dependencies-{{ checksum "requirements/test.txt" }}
 
     environment:
-      - TOX_ENV: py<< parameters.python_version >>-<< parameters.django_version >>
+      - PY_ENV: py<< parameters.python_version >>
+      - DJANGO_ENV: << parameters.django_version >>
 
   pypi:
     docker:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 Unreleased
 ----------
+* Drop support for python 2.7.
 
 [0.5.0] - 2021-04-13
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,6 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/tox.txt requirements/tox.in
 
-	grep -e "^django==" -e "^djangorestframework==" requirements/test.txt > requirements/django.txt
-	sed '/^[dD]jango==/d;/^djangorestframework==/d' requirements/test.txt > requirements/test.tmp
-	mv requirements/test.tmp requirements/test.txt
-
 quality: clean ## check coding style with pycodestyle and pylint
 	$(TOX) pycodestyle ./eox_hooks
 	$(TOX) pylint ./eox_hooks --rcfile=./setup.cfg

--- a/eox_hooks/__init__.py
+++ b/eox_hooks/__init__.py
@@ -2,7 +2,6 @@
 Init module for eox_hooks.
 """
 
-from __future__ import unicode_literals
 
 import django.dispatch
 

--- a/eox_hooks/apps.py
+++ b/eox_hooks/apps.py
@@ -2,7 +2,6 @@
 App configuration for eox_hooks.
 """
 
-from __future__ import unicode_literals
 
 from importlib import import_module
 

--- a/eox_hooks/edxapp_wrapper/backends/models.py
+++ b/eox_hooks/edxapp_wrapper/backends/models.py
@@ -7,7 +7,8 @@ from django.conf import settings
 def get_openedx_certificate_model():
     """Return the GeneratedCertificate model class when called during runtime"""
     if not getattr(settings, "EOX_HOOKS_TEST_ENVIRONMENT", False):
-        from lms.djangoapps.certificates.models import GeneratedCertificate  # pylint: disable=import-error
+        # pylint: disable=import-error,import-outside-toplevel
+        from lms.djangoapps.certificates.models import GeneratedCertificate
 
         return GeneratedCertificate
     # Return None when testing to avoid ImportError
@@ -17,7 +18,7 @@ def get_openedx_certificate_model():
 def get_openedx_user_profile_model():
     """Return the UserProfile model class when called during runtime"""
     if not getattr(settings, "EOX_HOOKS_TEST_ENVIRONMENT", False):
-        from student.models import UserProfile  # pylint: disable=import-error
+        from student.models import UserProfile  # pylint: disable=import-error,import-outside-toplevel
 
         return UserProfile
     # Return None when testing to avoid ImportError

--- a/eox_hooks/serializers.py
+++ b/eox_hooks/serializers.py
@@ -15,7 +15,7 @@ class CertificateSerializer(serializers.ModelSerializer):
     """
     created_date = serializers.DateTimeField(format="%Y-%m-%d", read_only=True)
 
-    class Meta(object):
+    class Meta:
         """Meta class."""
         model = get_openedx_certificate_model()
         fields = '__all__'
@@ -28,7 +28,7 @@ class RetirementUserProfileSerializer(serializers.ModelSerializer):
     country = serializers.CharField(read_only=True)
     meta = serializers.SerializerMethodField(read_only=True)
 
-    class Meta(object):
+    class Meta:
         """Meta class."""
         model = get_openedx_user_profile_model()
         fields = '__all__'
@@ -48,7 +48,7 @@ class UserSerializer(serializers.ModelSerializer):
     """
     profile = RetirementUserProfileSerializer(read_only=True)
 
-    class Meta(object):
+    class Meta:
         """Meta class."""
         model = get_user_model()
         exclude = ['password']

--- a/eox_hooks/settings/common.py
+++ b/eox_hooks/settings/common.py
@@ -8,7 +8,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
-from __future__ import unicode_literals
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/

--- a/eox_hooks/settings/production.py
+++ b/eox_hooks/settings/production.py
@@ -2,8 +2,6 @@
 Production Django settings for eox_hooks project.
 """
 
-from __future__ import unicode_literals
-
 
 def plugin_settings(settings):  # pylint: disable=unused-argument
     """

--- a/eox_hooks/settings/test.py
+++ b/eox_hooks/settings/test.py
@@ -2,7 +2,6 @@
 Test Django settings for eox_hooks project.
 """
 
-from __future__ import unicode_literals
 
 from .common import *  # pylint: disable=wildcard-import
 

--- a/eox_hooks/utils.py
+++ b/eox_hooks/utils.py
@@ -45,6 +45,6 @@ def get_trigger_settings(trigger_event):
 
 def _get_course(course_key):
     """Returns a course given its key."""
-    from xmodule.modulestore.django import modulestore  # pylint: disable=import-error
+    from xmodule.modulestore.django import modulestore  # pylint: disable=import-error,import-outside-toplevel
 
     return modulestore().get_course(course_key)

--- a/eox_hooks/views.py
+++ b/eox_hooks/views.py
@@ -3,7 +3,6 @@
 Methods:
     info_view: Show basic plugin information.
 """
-from __future__ import unicode_literals
 
 from os.path import dirname, realpath
 from subprocess import CalledProcessError, check_output

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,13 @@
 #
 #    make upgrade
 #
-django==1.11.29           # via -r requirements/base.in
-djangorestframework==3.6.3  # via -c requirements/constraints.txt, -r requirements/base.in
-pytz==2021.1              # via django
+django==2.2.24
+    # via -r requirements/base.in
+djangorestframework==3.9.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+pytz==2021.1
+    # via django
+sqlparse==0.4.1
+    # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,13 +8,12 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Already in python3 standard library
-futures; python_version == "2.7"
+# This version avoids conflict with wrapt
+pylint==2.5.0
 
 # TODO: Add constraint explanation
-pylint==1.9.3
-pycodestyle==2.5.0
+pycodestyle==2.6.0
 
 # Keep same platform version
-djangorestframework==3.6.3
+djangorestframework==3.9.4
 testfixtures==6.4.3

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,2 +1,0 @@
-django==1.11.29           # via -r requirements/base.txt
-djangorestframework==3.6.3  # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/django22.txt
+++ b/requirements/django22.txt
@@ -1,2 +1,0 @@
-Django==2.2.16
-djangorestframework==3.9.4

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,10 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -r requirements/pip-tools.in
+click==7.1.2
+    # via pip-tools
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,20 +4,61 @@
 #
 #    make upgrade
 #
-astroid==1.6.6            # via pylint
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-coverage==5.4             # via -r requirements/test.in
-idna==2.10                # via requests
-isort==4.3.21             # via pylint
-lazy-object-proxy==1.5.2  # via astroid
-mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -r requirements/test.in
-pycodestyle==2.5.0        # via -c requirements/constraints.txt, -r requirements/test.in
-pylint==1.9.3             # via -c requirements/constraints.txt, -r requirements/test.in
-pytz==2021.1              # via -r requirements/base.txt, django
-requests==2.25.1          # via -r requirements/test.in
-six==1.15.0               # via astroid, mock, pylint
-testfixtures==6.4.3       # via -c requirements/constraints.txt, -r requirements/test.in
-urllib3==1.26.3           # via requests
-wrapt==1.12.1             # via astroid
+astroid==2.4.2
+    # via pylint
+certifi==2021.5.30
+    # via requests
+chardet==4.0.0
+    # via requests
+coverage==5.5
+    # via -r requirements/test.in
+django==2.2.24
+    # via -r requirements/base.txt
+djangorestframework==3.9.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+idna==2.10
+    # via requests
+isort==4.3.21
+    # via pylint
+lazy-object-proxy==1.4.3
+    # via astroid
+mccabe==0.6.1
+    # via pylint
+mock==3.0.5
+    # via -r requirements/test.in
+pycodestyle==2.6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+pylint==2.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+requests==2.25.1
+    # via -r requirements/test.in
+six==1.16.0
+    # via
+    #   astroid
+    #   mock
+sqlparse==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+testfixtures==6.4.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+toml==0.10.2
+    # via pylint
+typed-ast==1.4.3
+    # via astroid
+urllib3==1.26.6
+    # via requests
+wrapt==1.12.1
+    # via astroid

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,43 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-packaging==20.9           # via tox
-pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
-pyparsing==2.4.7          # via packaging
-six==1.15.0               # via tox, virtualenv
-toml==0.10.2              # via tox
-tox==3.22.0               # via -r requirements/tox.in
-virtualenv==20.4.2        # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
+distlib==0.3.2
+    # via virtualenv
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+importlib-metadata==2.1.1
+    # via
+    #   backports.entry-points-selectable
+    #   pluggy
+    #   tox
+    #   virtualenv
+importlib-resources==3.2.1
+    # via virtualenv
+packaging==20.9
+    # via tox
+platformdirs==2.0.2
+    # via virtualenv
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pyparsing==2.4.7
+    # via packaging
+six==1.16.0
+    # via
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via tox
+tox==3.24.1
+    # via -r requirements/tox.in
+virtualenv==20.7.1
+    # via tox
+zipp==1.2.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,10 @@ envlist = py27-django111,py35-django{111,22}
 [testenv]
 envdir=
     # Use the same environment for all commands running under a specific python version
-    py27: {toxworkdir}/py27
     py35: {toxworkdir}/py35
+    py38: {toxworkdir}/py38
 
 deps =
-    django111: -r requirements/django.txt
-    django22: -r requirements/django22.txt
     -rrequirements/test.txt
 commands =
     {posargs}


### PR DESCRIPTION
This PR drops support for python2.7 and django11 and adds tests for python3.8 as in the other plugins