### PR TITLE
Receiver to catch persistent grade event.

### DIFF
--- a/eox_hooks/apps.py
+++ b/eox_hooks/apps.py
@@ -109,6 +109,12 @@ class EoxHooksConfig(AppConfig):
                         'signal_path': 'openedx_events.learning.signals.COHORT_MEMBERSHIP_CHANGED',
                         'dispatch_uid': 'eox-hooks:post_cohort_change',
                     },
+                    {
+                        'receiver_func_name': 'hooks_handler',
+                        # pylint: disable=line-too-long
+                        'signal_path': 'openedx_events.learning.signals.PERSISTENT_GRADE_SUMMARY_CHANGED',
+                        'dispatch_uid': 'eox-hooks:persistent_grade_summary_changed',
+                    },
                 ],
             }
         },


### PR DESCRIPTION
This pull request is intended to receive an event generated by a persistent grade, if you want to see the definition and usage of the event you can view the following PRs.

- [openedx-events](https://github.com/openedx/openedx-events/pull/99)

- [edx-platform](https://github.com/openedx/edx-platform/pull/30916)

### Steps to probe this PR.

1. You have to install this version of eox-hooks in your openedx installation.
2. You have to make a cherry pick from this commit `9b8fc7652f67181380708a9a821118340f70c9ca` (which you can find in this PR [30916](https://github.com/openedx/edx-platform/pull/30916)) to your edx-platform or edunext-platform repository and resolve the conflicts.
3. then you can configure your eox-hooks as usual. below there is an example of the configuration.
```yaml
 "USE_EOX_HOOKS": true,
 "EOX_HOOKS_DEFINITIONS": {
        "post_enrollment": {
            "action": "post_to_webhook_url", 
            "config": {
                "fields": {
                    "user_id": "grade.user_id",
                    "course" : "grade.course.course_key",
                    "course_edited_timestamp": "grade.course_edited_timestamp",
                    "grading_policy_hash": "grade.grading_policy_hash",
                    "letter_grade": "grade.letter_grade",
                    "percent_grade": "grade.percent_grade",
                    "passed_timestamp": "grade.passed_timestamp"
                }, 
                "send_certificate_data": false, 
                "url": "zapier-or-webhook-url"
            }, 
            "fail_silently": true, 
            "module": "eox_hooks.actions"
        }, 
    }, 
```
Note: please replace `zapier-or-webhook-url` with your webhook URL if you don't have a zapier account you can use this page https://webhook.site.
