### PR TITLE
fix: adding a fake request to execute in async servers

### DIFF
--- a/eox_hooks/actions.py
+++ b/eox_hooks/actions.py
@@ -11,7 +11,7 @@ from eox_hooks.edxapp_wrapper.courses import get_item_not_found_exception, get_l
 from eox_hooks.edxapp_wrapper.models import get_certificate_model
 from eox_hooks.serializers import CertificateSerializer, CourseSerializer, UserSerializer
 from eox_hooks.tasks import create_enrollments_for_program
-from eox_hooks.utils import _get_course, flatten_dict, get_trigger_settings
+from eox_hooks.utils import FakeRequest, _get_course, flatten_dict, get_trigger_settings
 
 COURSE_PASSING_GRADE = 1
 ItemNotFoundError = get_item_not_found_exception()
@@ -218,7 +218,7 @@ def trigger_grades_assignment(**kwargs):
     else:
         grade = COURSE_PASSING_GRADE
 
-    django_request = get_current_request()
+    django_request = FakeRequest() if not get_current_request() else get_current_request()
 
     try:
         xblock_instance = load_single_xblock(
@@ -233,5 +233,8 @@ def trigger_grades_assignment(**kwargs):
         return
 
     xblock_instance.runtime.publish(
-        xblock_instance, "grade", {"value": grade, "max_value": xblock_instance.weight}
+        xblock_instance, "grade", {
+            "value": float(grade),
+            "max_value": float(xblock_instance.weight)
+        }
     )

--- a/eox_hooks/utils.py
+++ b/eox_hooks/utils.py
@@ -6,6 +6,28 @@ import collections
 from django.conf import settings
 
 
+class FakeRequest:
+    """
+    This class represents a fake request, this is needed when the action
+    "trigger_grades_assignment" is executed in an async server.
+    """
+    META = {}
+
+    @staticmethod
+    def is_secure():
+        """
+        Returns a True to mock-up https.
+        """
+        return True
+
+    @staticmethod
+    def get_host():
+        """
+        Returns a string with the site name to mock-up the host.
+        """
+        return settings.SITE_NAME
+
+
 def flatten_dict(dictionary, parent_key='', sep='_'):
     """
     This function returns a flatten dictionary-like object.


### PR DESCRIPTION
Hi team!

This PR is needed to implement programs in a stratus installation, you can read more about this in the following link [more context](https://3.basecamp.com/3966315/buckets/12732851/documents/5430547746), additionally, this is the solution for the following issue #34.

## How to test it.

1. Create a local environment with mango, if you want to see the error you have to use the current version of eox-hooks.
2. Configure your programs, to configure programs. you also have to configure grading and certificates, this is mandatory because this functionality needs that a trigger will be generated when you request a certificate, if you want to know further information about how to configure programs, these links are very useful.
   -  [Multi Courses Programs Public Documenation](https://docs.edunext.co/en/public/external/prepare_test_launch_courses/multi-course-programs.html)
   -  [Multi Courses Programs Internal Documentation](https://docs.edunext.co/en/latest/internal/special-features/programs/programs.html)
3. if you have your programs working, then, you can see the logs on the lms or lms-worker container, it's important to configure your local environment for working with workers.
4. when you see the error, further information about the error is in this issue #34, if you want to solve it, you can install eox-hooks with the following branch `dmh/fixing-programs` to test that the issue is fixed.