### PR TITLE
feat: allow a child course to belong to multiples parents

### DIFF
--- a/eox_hooks/tests/test_actions.py
+++ b/eox_hooks/tests/test_actions.py
@@ -233,12 +233,12 @@ class TriggerGradingTest(TestCase):
         # -------- programs ---------
         self.grading_config_programs = [
             {
-            "block_id": "467f8ab131634e52bb6c22b60940d857",
-            "program_id": "course-v1:edx+DemoX+Demo_Course",
+                "block_id": "467f8ab131634e52bb6c22b60940d857",
+                "program_id": "course-v1:edx+DemoX+Demo_Course"
             },
             {
-            "block_id": "467f8ab131634e52bb6c22b60940d856",
-            "program_id": "course-v1:edx2+DemoX+Demo_Course",
+                "block_id": "467f8ab131634e52bb6c22b60940d856",
+                "program_id": "course-v1:edx2+DemoX+Demo_Course"
             }
         ]
 
@@ -347,7 +347,6 @@ class TriggerGradingTest(TestCase):
         """
         for grading_config in self.grading_config_programs:
             mock_course = MagicMock()
-            
             grading_config["exact_score"] = True
             mock_course.other_course_settings.get.return_value = grading_config
             get_course.return_value = mock_course

--- a/eox_hooks/tests/test_actions.py
+++ b/eox_hooks/tests/test_actions.py
@@ -230,6 +230,18 @@ class TriggerGradingTest(TestCase):
             self.grading_config.get("block_id")
         )
 
+        # -------- programs ---------
+        self.grading_config_programs = [
+            {
+            "block_id": "467f8ab131634e52bb6c22b60940d857",
+            "program_id": "course-v1:edx+DemoX+Demo_Course",
+            },
+            {
+            "block_id": "467f8ab131634e52bb6c22b60940d856",
+            "program_id": "course-v1:edx2+DemoX+Demo_Course",
+            }
+        ]
+
     @load_xblock
     @get_course
     def test_course_without_settings(self, get_course, load_xblock):
@@ -322,3 +334,32 @@ class TriggerGradingTest(TestCase):
                 "max_value": 1,
             }
         )
+
+    @load_xblock
+    @get_course
+    def test_trigger_exact_grade_2_programs(self, get_course, load_xblock):
+        """
+        Tests action when the user gets a certificate from a course that belongs to
+        a program. This version propagates the exact grade obtained in the course.
+
+        Expected behavior:
+            - Action propagates the passing grade to the program(s) course(s).
+        """
+        for grading_config in self.grading_config_programs:
+            mock_course = MagicMock()
+            
+            grading_config["exact_score"] = True
+            mock_course.other_course_settings.get.return_value = grading_config
+            get_course.return_value = mock_course
+            load_xblock.return_value.weight = 1
+
+            trigger_grades_assignment(**self.kwargs)
+
+            load_xblock.return_value.runtime.publish(
+                load_xblock.return_value,
+                "grade",
+                {
+                    "value": 0.5,
+                    "max_value": 1,
+                }
+            )


### PR DESCRIPTION
Hi team!

This changes affect the Learner and Course Author.

In the section of the child courses, you can add a list of dicts, this is needed when the certificate is generated, the grade is propagated to the parent courses.


How to test it:

- Create two parent courses
- Create a child course
- Follow the steps in the [documentation](https://internal.docs.edunext.co/en/latest/internal/Teams/Service_Delivery/special-features/programs/programs.html?highlight=programs)  to how to configure a program
- In the CMS > Advance settings > Other Course Settings > EDNX_TRIGGER_GRADES_ASSIGNMENT add a list with block_id, program_id with the respective parent course.
``` json

{
    "EDNX_TRIGGER_GRADES_ASSIGNMENT": [
      {
        "block_id": "<parent_course_block_id #1>",
        "program_id": "<parent_course_id #1>",
        "exact_score": true
      },
      {
        "block_id": "<parent_course_block_id #2>",
        "program_id": "<parent_course_id #2>",
        "exact_score": true
      }
    ]
}
```

