### PR TITLE
fix: valitade enrollment for programs

### DIFF
--- a/eox_hooks/actions.py
+++ b/eox_hooks/actions.py
@@ -158,9 +158,14 @@ def trigger_enrollments_creation(**kwargs):
 
     if not followup_enrollments:
         return
+    
+    followup_list =[]
+    for enroll in followup_enrollments:
+        if str(enrollment.course.course_key) != enroll['course_id']:
+            followup_list.append(enroll)
 
     create_enrollments_for_program.delay(
-        enrollment.user.pii.username, followup_enrollments,
+        enrollment.user.pii.username, followup_list,
     )
 
 

--- a/eox_hooks/actions.py
+++ b/eox_hooks/actions.py
@@ -158,8 +158,7 @@ def trigger_enrollments_creation(**kwargs):
 
     if not followup_enrollments:
         return
-    
-    followup_list =[]
+    followup_list = []
     for enroll in followup_enrollments:
         if str(enrollment.course.course_key) != enroll['course_id']:
             followup_list.append(enroll)

--- a/eox_hooks/tests/test_actions.py
+++ b/eox_hooks/tests/test_actions.py
@@ -166,7 +166,7 @@ class TriggerEnrollmentsTest(TestCase):
         other_course_settings = {
             "EDNX_TRIGGER_FOLLOWUP_ENROLLMENTS": [
                 {
-                    "course_id": "course-v1:edX+DemoX+Demo_Course",
+                    "course_id": "course-v1:edX+Demo123+Demo_Course",
                 },
             ],
         }
@@ -179,7 +179,7 @@ class TriggerEnrollmentsTest(TestCase):
             "test",
             [
                 {
-                    "course_id": "course-v1:edX+DemoX+Demo_Course",
+                    "course_id": "course-v1:edX+Demo123+Demo_Course",
                 },
             ],
         )


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

Hi team,

This PR is intended to fix the loop in the enrollments action when the trigger_enrollments_creation is activated. 

## For testing:

In Studio >  select parent course > Settings > Advance Settings > Other Course Settings > add 

`{
    "EDNX_TRIGGER_FOLLOWUP_ENROLLMENTS": [
        {
            "course_id": "<same_parent_course_id>",
            "mode": "honor"
        }
    ]
}
`

This will skip the enrollments with the same course_id as the parent. Only will be triggered when the course_id is different that the parent.

