### PR TITLE
feat: add Lilac backend

### DIFF
--- a/eox_hooks/edxapp_wrapper/backends/courses_l_v1.py
+++ b/eox_hooks/edxapp_wrapper/backends/courses_l_v1.py
@@ -1,0 +1,25 @@
+"""
+Backend file for Course related objects.
+"""
+
+
+def get_load_single_xblock():
+    """
+    Gets load_single_xblock function from edxapp.
+
+    Returns:
+        [Function]: load_single_xblock function.
+    """
+    from lms.djangoapps.courseware.module_render import load_single_xblock  # pylint: disable=C0415, E0401
+    return load_single_xblock
+
+
+def get_item_not_found_exception():
+    """
+    Gets ItemNotFoundError exception from edxapp.
+
+    Returns:
+        [Class]: ItemNotFoundError exception.
+    """
+    from xmodule.modulestore.exceptions import ItemNotFoundError  # pylint: disable=C0415, E0401
+    return ItemNotFoundError


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR adds a Lilac backend which was removed in the migration to Palm.

## Testing instructions

1. Create an environment with Palm release, you can use [Tutor](https://docs.tutor.overhang.io/index.html) or [TVM](https://github.com/eduNEXT/tvm)
2. Install the Django plugin eox-hooks, you can use steps in [Tutor documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).
3. Run [test cases](https://docs.google.com/document/d/1f7LkXyxUbBcAdkDsWhtEzNfVNFFmV65enpKrEUUnirw/edit?usp=sharing) 
