### PR TITLE
feat: add api test

### DIFF
--- a/eox_hooks/settings/test.py
+++ b/eox_hooks/settings/test.py
@@ -47,6 +47,7 @@ DATABASES = {
     }
 }
 
+SITE_ID=2
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """

--- a/eox_hooks/settings/test.py
+++ b/eox_hooks/settings/test.py
@@ -47,7 +47,6 @@ DATABASES = {
     }
 }
 
-SITE_ID=2
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """

--- a/eox_hooks/tests/tutor/integration_test_tutor.py
+++ b/eox_hooks/tests/tutor/integration_test_tutor.py
@@ -4,7 +4,7 @@ Test integration file.
 from django.test import TestCase, override_settings
 
 
-@override_settings(ALLOWED_HOSTS=['local.edly.io'], SITE_ID=2)
+@override_settings(ALLOWED_HOSTS=['local.edly.io'])
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx

--- a/eox_hooks/tests/tutor/integration_test_tutor.py
+++ b/eox_hooks/tests/tutor/integration_test_tutor.py
@@ -4,12 +4,12 @@ Test integration file.
 from django.test import TestCase, override_settings
 
 
-@override_settings(ALLOWED_HOSTS=['local.edly.io'])
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx
     """
 
+    @override_settings(ALLOWED_HOSTS=['local.edly.io'])
     def setUp(self):
         """
         Set up the base URL for the tests

--- a/eox_hooks/tests/tutor/integration_test_tutor.py
+++ b/eox_hooks/tests/tutor/integration_test_tutor.py
@@ -30,7 +30,7 @@ class TutorIntegrationTestCase(TestCase):
         """
         Tests the info view endpoint in Tutor
         """
-        info_view_url = f'{self.base_url}/eox-hooks/eox-info/'
+        info_view_url = f'{self.base_url}/eox-hooks/eox-info'
 
         # Simulate a GET request to the info endpoint using the full URL
         response = self.client.get(info_view_url)

--- a/eox_hooks/tests/tutor/integration_test_tutor.py
+++ b/eox_hooks/tests/tutor/integration_test_tutor.py
@@ -4,12 +4,12 @@ Test integration file.
 from django.test import TestCase, override_settings
 
 
+@override_settings(ALLOWED_HOSTS=['local.edly.io'], SITE_ID=2)
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx
     """
 
-    @override_settings(ALLOWED_HOSTS=['local.edly.io'])
     def setUp(self):
         """
         Set up the base URL for the tests

--- a/eox_hooks/tests/tutor/integration_test_tutor.py
+++ b/eox_hooks/tests/tutor/integration_test_tutor.py
@@ -1,13 +1,20 @@
 """
 Test integration file.
 """
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx
     """
+
+    @override_settings(ALLOWED_HOSTS=['local.edly.io'])
+    def setUp(self):
+        """
+        Set up the base URL for the tests
+        """
+        self.base_url = 'http://local.edly.io'
 
     # pylint: disable=import-outside-toplevel,unused-import
     def test_current_settings_code_imports(self):
@@ -18,3 +25,21 @@ class TutorIntegrationTestCase(TestCase):
         import eox_hooks.edxapp_wrapper.backends.courses_p_v1  # isort:skip
         import eox_hooks.edxapp_wrapper.backends.enrollments_l_v1  # isort:skip
         import eox_hooks.edxapp_wrapper.backends.models_l_v1  # isort:skip
+
+    def test_info_view(self):
+        """
+        Tests the info view endpoint in Tutor
+        """
+        info_view_url = f'{self.base_url}/eox-hooks/eox-info/'
+
+        # Simulate a GET request to the info endpoint using the full URL
+        response = self.client.get(info_view_url)
+
+        # Verify the response status code
+        self.assertEqual(response.status_code, 200)
+
+        # Verify the response format
+        response_data = response.json()
+        self.assertIn('version', response_data)
+        self.assertIn('name', response_data)
+        self.assertIn('git', response_data)

--- a/eox_hooks/tests/tutor/integration_test_tutor.py
+++ b/eox_hooks/tests/tutor/integration_test_tutor.py
@@ -4,7 +4,7 @@ Test integration file.
 from django.test import TestCase, override_settings
 
 
-@override_settings(ALLOWED_HOSTS=['local.edly.io'], SITE_ID=2)
+@override_settings(ALLOWED_HOSTS=['local.edly.io', 'testserver'], SITE_ID=2)
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx

--- a/eox_hooks/tests/tutor/integration_test_tutor.py
+++ b/eox_hooks/tests/tutor/integration_test_tutor.py
@@ -4,7 +4,7 @@ Test integration file.
 from django.test import TestCase, override_settings
 
 
-@override_settings(ALLOWED_HOSTS=['local.edly.io', 'testserver'], SITE_ID=2)
+@override_settings(ALLOWED_HOSTS=['testserver'], SITE_ID=2)
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx
@@ -32,13 +32,10 @@ class TutorIntegrationTestCase(TestCase):
         """
         info_view_url = f'{self.base_url}/eox-hooks/eox-info'
 
-        # Simulate a GET request to the info endpoint using the full URL
         response = self.client.get(info_view_url)
 
-        # Verify the response status code
         self.assertEqual(response.status_code, 200)
 
-        # Verify the response format
         response_data = response.json()
         self.assertIn('version', response_data)
         self.assertIn('name', response_data)


### PR DESCRIPTION
## Description
This PR adds validation for the /eox-hooks/eox-info endpoint in the integration test

## How to test
Checks:

- Integration / integration-test (<17.0.0) (pull_request)

- Integration / integration-test (<18.0.0) (pull_request)

## Other information

SITE_ID = 2 is used to fix the error: django.contrib.sites.models.Site.DoesNotExist: Site match query does not exist.

When running an instance, SITE_ID is 2, so the setting was overridden
 so that during testing it also takes the SITE_ID = 2

https://edunext.atlassian.net/browse/DS-993