### PR TITLE
chore: removed unnecessary constraints

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.2.0
+amqp==5.3.1
     # via kombu
 asgiref==3.8.1
     # via django
@@ -23,12 +23,15 @@ celery==5.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+cffi==1.17.1
+    # via pynacl
 click==8.1.7
     # via
     #   celery
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   edx-django-utils
 click-didyoumean==0.3.1
     # via celery
 click-plugins==1.1.1
@@ -40,40 +43,61 @@ django==4.2.16
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-crum
+    #   django-waffle
     #   djangorestframework
+    #   edx-django-utils
     #   openedx-events
 django-crum==0.7.9
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   edx-django-utils
+django-waffle==4.2.0
+    # via edx-django-utils
 djangorestframework==3.15.2
     # via -r requirements/base.in
 dnspython==2.6.1
     # via pymongo
+edx-ccx-keys==1.3.0
+    # via openedx-events
+edx-django-utils==7.0.0
+    # via openedx-events
 edx-opaque-keys[django]==2.11.0
     # via
     #   -r requirements/base.in
+    #   edx-ccx-keys
     #   openedx-events
 fastavro==1.9.7
     # via openedx-events
 kombu==5.4.2
     # via celery
-openedx-events==9.0.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+newrelic==10.2.0
+    # via edx-django-utils
+openedx-events==9.14.1
+    # via -r requirements/base.in
 pbr==6.1.0
     # via stevedore
 prompt-toolkit==3.0.48
     # via click-repl
+psutil==6.1.0
+    # via edx-django-utils
+pycparser==2.22
+    # via cffi
 pymongo==4.10.1
     # via edx-opaque-keys
+pynacl==1.5.0
+    # via edx-django-utils
 python-dateutil==2.9.0.post0
     # via celery
 six==1.16.0
-    # via python-dateutil
-sqlparse==0.5.1
+    # via
+    #   edx-ccx-keys
+    #   python-dateutil
+sqlparse==0.5.2
     # via django
 stevedore==5.3.0
-    # via edx-opaque-keys
+    # via
+    #   edx-django-utils
+    #   edx-opaque-keys
 typing-extensions==4.12.2
     # via
     #   asgiref

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,8 +16,8 @@
 # the next major release, ensure the installed version is within boundaries.
 celery>=5.2.2,<6.0.0
 
+#Necessary for python 3.8
 openedx-events<=9.0.0
-pytz<=2022.7.1
 
 # backports.zoneinfo is only needed for Python < 3.9
 backports.zoneinfo; python_version<'3.9'

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,8 +16,5 @@
 # the next major release, ensure the installed version is within boundaries.
 celery>=5.2.2,<6.0.0
 
-#Necessary for python 3.8
-openedx-events<=9.0.0
-
 # backports.zoneinfo is only needed for Python < 3.9
 backports.zoneinfo; python_version<'3.9'

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,6 +14,7 @@
 
 # As it is not clarified what exact breaking changes will be introduced as per
 # the next major release, ensure the installed version is within boundaries.
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35280
 celery>=5.2.2,<6.0.0
 
 # backports.zoneinfo is only needed for Python < 3.9

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.7
     # via pip-tools
 importlib-metadata==8.5.0
     # via build
-packaging==24.1
+packaging==24.2
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
@@ -18,11 +18,11 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   build
     #   pip-tools
-wheel==0.44.0
+wheel==0.45.0
     # via pip-tools
 zipp==3.20.2
     # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.2.0
+amqp==5.3.1
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -36,6 +36,10 @@ celery==5.4.0
     #   -r requirements/base.txt
 certifi==2024.8.30
     # via requests
+cffi==1.17.1
+    # via
+    #   -r requirements/base.txt
+    #   pynacl
 charset-normalizer==3.4.0
     # via requests
 click==8.1.7
@@ -45,6 +49,7 @@ click==8.1.7
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   edx-django-utils
 click-didyoumean==0.3.1
     # via
     #   -r requirements/base.txt
@@ -65,19 +70,36 @@ dill==0.3.9
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   django-crum
+    #   django-waffle
     #   djangorestframework
+    #   edx-django-utils
     #   openedx-events
 django-crum==0.7.9
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+django-waffle==4.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
 djangorestframework==3.15.2
     # via -r requirements/base.txt
 dnspython==2.6.1
     # via
     #   -r requirements/base.txt
     #   pymongo
+edx-ccx-keys==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
+edx-django-utils==7.0.0
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 edx-opaque-keys[django]==2.11.0
     # via
     #   -r requirements/base.txt
+    #   edx-ccx-keys
     #   openedx-events
 exceptiongroup==1.2.2
     # via pytest
@@ -99,11 +121,13 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.in
-openedx-events==9.0.0
+newrelic==10.2.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-packaging==24.1
+    #   edx-django-utils
+openedx-events==9.14.1
+    # via -r requirements/base.txt
+packaging==24.2
     # via pytest
 pbr==6.1.0
     # via
@@ -117,14 +141,26 @@ prompt-toolkit==3.0.48
     # via
     #   -r requirements/base.txt
     #   click-repl
+psutil==6.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
 pycodestyle==2.12.1
     # via -r requirements/test.in
+pycparser==2.22
+    # via
+    #   -r requirements/base.txt
+    #   cffi
 pylint==3.2.7
     # via -r requirements/test.in
 pymongo==4.10.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
 pytest==8.3.3
     # via
     #   -r requirements/test.in
@@ -142,18 +178,20 @@ requests==2.32.3
 six==1.16.0
     # via
     #   -r requirements/base.txt
+    #   edx-ccx-keys
     #   python-dateutil
-sqlparse==0.5.1
+sqlparse==0.5.2
     # via
     #   -r requirements/base.txt
     #   django
 stevedore==5.3.0
     # via
     #   -r requirements/base.txt
+    #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==8.3.0
     # via -r requirements/test.in
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   pylint
     #   pytest

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -16,7 +16,7 @@ filelock==3.16.1
     # via
     #   tox
     #   virtualenv
-packaging==24.1
+packaging==24.2
     # via
     #   pyproject-api
     #   tox
@@ -28,7 +28,7 @@ pluggy==1.5.0
     # via tox
 pyproject-api==1.8.0
     # via tox
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   pyproject-api
     #   tox

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -36,5 +36,5 @@ tox==4.23.2
     # via -r requirements/tox.in
 typing-extensions==4.12.2
     # via tox
-virtualenv==20.27.0
+virtualenv==20.27.1
     # via tox


### PR DESCRIPTION
**Description**

This PR removes the pytz constraint as the latest version was used on edx-platform and added a comment on why openedx-events < 9.0.0 is necessary for python 3.8