### PR TITLE
feat: add custom headers and data unflattening to webhook actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v8.4.0](https://github.com/eduNEXT/eox-hooks/compare/v8.3.0...v8.4.0) - (2026-01-19)
+
+### Added
+- **Custom Headers**: Webhook actions now support a `headers` dictionary in the trigger configuration, allowing for `Authorization` tokens and other custom metadata.
+- **Data Unflattening**: Introduced the `unflatten_data` setting. When enabled, flat data keys (e.g., `user.profile.name`) are expanded into nested JSON objects before the POST request.
+- **Course Context**: Added the `use_course_information` flag to automatically inject course data into the webhook payload during certificate events.
+- **New Utility**: Added `unflatten_dict` in `eox_hooks.utils` to handle complex dictionary expansions.
+
+### Changed
+- **Refactoring**: Certificate retrieval logic in `post_to_webhook_url` was moved to a dedicated `get_certificate` function for better maintainability.
+- **Webhook Payload**: The `post` request now defaults to `json=data` when `unflatten_data` is active, improving compatibility with modern API endpoints.
+
 ## [v8.3.0](https://github.com/eduNEXT/eox-hooks/compare/v8.2.0...v8.3.0) - (2025-10-13)
 
 ### Changed

--- a/eox_hooks/__init__.py
+++ b/eox_hooks/__init__.py
@@ -5,7 +5,7 @@ Init module for eox_hooks.
 
 import django.dispatch
 
-__version__ = '8.3.0'
+__version__ = '8.4.0'
 
 
 dummy_signal = django.dispatch.Signal()

--- a/eox_hooks/actions.py
+++ b/eox_hooks/actions.py
@@ -11,7 +11,14 @@ from eox_hooks.edxapp_wrapper.courses import get_item_not_found_exception, get_l
 from eox_hooks.edxapp_wrapper.models import get_certificate_model
 from eox_hooks.serializers import CertificateSerializer, CourseSerializer, UserSerializer
 from eox_hooks.tasks import create_enrollments_for_program
-from eox_hooks.utils import FakeRequest, _get_course, flatten_dict, get_trigger_settings
+
+from eox_hooks.utils import (  # isort: skip
+    FakeRequest,
+    _get_course,
+    flatten_dict,
+    get_trigger_settings,
+    unflatten_dict,
+)
 
 COURSE_PASSING_GRADE = 1
 ItemNotFoundError = get_item_not_found_exception()
@@ -38,6 +45,9 @@ def post_to_webhook_url(**kwargs):
                 },
                 "extra_fields": {
                     "email_message": "Something extra."
+                },
+                "headers": {
+                    "Authorization": "Token token=YOUR_API_KEY"
                 }
             }
             ...
@@ -58,23 +68,42 @@ def post_to_webhook_url(**kwargs):
     webhook_url = trigger_settings.get("url", "")
     fields = trigger_settings.get("fields", {})
     extra_fields = trigger_settings.get("extra_fields", {})
+    headers = trigger_settings.get("headers", {})
+
+    if trigger_settings.get("use_course_information", False):
+        certificate = get_certificate(**kwargs)
+        course = _get_course(certificate.course_id)
+        kwargs.update({"course": course})
 
     data = get_request_fields(fields, extra_fields, **kwargs)
 
     if trigger_settings.get("send_certificate_data", False):
-        certificate = kwargs.get("certificate", {})
-        certificate = GeneratedCertificate.objects.get(
-            user__id=certificate.user.id, course_id=certificate.course.course_key,
-        )
+        certificate = get_certificate(**kwargs)
         extended_data = get_extended_certificate_data(certificate)
         data.update(extended_data)
 
-    response = requests.post(webhook_url, flatten_dict(data))  # pylint: disable=W3101
+    if trigger_settings.get("unflatten_data", False):
+        data = unflatten_dict(data)
+        response = requests.post(webhook_url, json=data, headers=headers)  # pylint: disable=W3101
+    else:
+        response = requests.post(webhook_url, flatten_dict(data), headers=headers)  # pylint: disable=W3101
     log.info(
         "post_to_webhook_url request information: %s",
         response.text,
     )
     return response.status_code == 200
+
+
+def get_certificate(**kwargs):
+    """
+    Retrieve the GeneratedCertificate instance from the kwargs.
+    """
+    certificate_data = kwargs.get("certificate")
+    certificate = GeneratedCertificate.objects.get(
+        user__id=certificate_data.user.id,
+        course_id=certificate_data.course.course_key,
+    )
+    return certificate
 
 
 def get_extended_certificate_data(certificate):

--- a/eox_hooks/tests/test_actions.py
+++ b/eox_hooks/tests/test_actions.py
@@ -12,7 +12,12 @@ from opaque_keys.edx.keys import CourseKey
 # pylint: disable=line-too-long
 from openedx_events.learning.data import CertificateData, CourseData, CourseEnrollmentData, UserData, UserPersonalData
 
-from eox_hooks.actions import get_request_fields, trigger_enrollments_creation, trigger_grades_assignment
+from eox_hooks.actions import (
+    get_request_fields,
+    post_to_webhook_url,
+    trigger_enrollments_creation,
+    trigger_grades_assignment,
+)
 
 
 class TestPostToWebhookUrl(TestCase):
@@ -80,6 +85,57 @@ class TestPostToWebhookUrl(TestCase):
         result_data = get_request_fields(fields, extra_fields, **self.kwargs)
 
         self.assertEqual(expected_data, result_data)
+
+    @patch('eox_hooks.actions.requests.post')
+    @patch('eox_hooks.actions.get_trigger_settings')
+    def test_post_to_webhook_url_with_custom_headers(self, mock_settings, mock_post):
+        """
+        Used to test post_to_webhook_url with custom headers.
+
+        This should verify that the headers defined in the configuration are passed
+        correctly to the requests call.
+        """
+        mock_settings.return_value = {
+            "url": "https://webhook.site/test",
+            "headers": {
+                "Authorization": "Token token=secret_key_123",
+                "X-Custom-Header": "CustomValue"
+            },
+            "fields": {"email": "user.pii.email"}
+        }
+        mock_post.return_value.status_code = 200
+
+        self.kwargs['trigger_event'] = 'post_certificate_creation'
+        result = post_to_webhook_url(**self.kwargs)
+
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs['headers']['Authorization'], "Token token=secret_key_123")
+        self.assertEqual(kwargs['headers']['X-Custom-Header'], "CustomValue")
+        self.assertTrue(result)
+
+    @patch('eox_hooks.actions.requests.post')
+    @patch('eox_hooks.actions.get_trigger_settings')
+    def test_post_to_webhook_url_without_headers_in_config(self, mock_settings, mock_post):
+        """
+        Used to test post_to_webhook_url without headers in config.
+
+        This should verify that the function does not fail if the 'headers' field
+        does not exist in the configuration (backward compatibility).
+        """
+        mock_settings.return_value = {
+            "url": "https://webhook.site/test",
+            "fields": {"username": "user.pii.username"}
+        }
+        mock_post.return_value.status_code = 200
+
+        self.kwargs['trigger_event'] = 'post_certificate_creation'
+
+        result = post_to_webhook_url(**self.kwargs)
+
+        _, kwargs = mock_post.call_args
+        self.assertIn('headers', kwargs)
+        self.assertEqual(kwargs['headers'], {})
+        self.assertTrue(result)
 
 
 class TriggerEnrollmentsTest(TestCase):

--- a/eox_hooks/tests/test_utils.py
+++ b/eox_hooks/tests/test_utils.py
@@ -3,7 +3,7 @@ Test utils functions.
 """
 from django.test import TestCase
 
-from eox_hooks.utils import flatten_dict
+from eox_hooks.utils import flatten_dict, unflatten_dict
 
 
 def custom_action_mock(**kwargs):  # pylint: disable=unused-argument
@@ -51,3 +51,55 @@ class TestUtils(TestCase):
         result_data = flatten_dict(data)
 
         self.assertEqual(expected_data, result_data)
+
+    def test_unflatten_dict_default_delimiter(self):
+        """
+        Used to test unflatten_dict function with default delimiter
+
+        This should return a nested dictionary matching the original hierarchy.
+        """
+        flat_data = {
+            "base.footer.logo_url": "https://edunext.co",
+            "base.footer.copy": "All rights reserved",
+            "foo": "eduNEXT",
+        }
+        expected_nested = {
+            "base": {
+                "footer": {
+                    "logo_url": "https://edunext.co",
+                    "copy": "All rights reserved",
+                }
+            },
+            "foo": "eduNEXT",
+        }
+
+        nested = unflatten_dict(flat_data)
+
+        self.assertEqual(expected_nested, nested)
+
+    def test_unflatten_dict_custom_delimiter(self):
+        """
+        Used to test unflatten_dict function with custom delimiter
+
+        This should return a nested dictionary even when using a non-default delimiter.
+        """
+        flat_data = {
+            "user|profile|name": "Alice",
+            "user|profile|age": 30,
+            "course|id": "C001",
+        }
+        expected_nested = {
+            "user": {
+                "profile": {
+                    "name": "Alice",
+                    "age": 30,
+                }
+            },
+            "course": {
+                "id": "C001",
+            },
+        }
+
+        nested = unflatten_dict(flat_data, delimiter="|")
+
+        self.assertEqual(expected_nested, nested)

--- a/eox_hooks/utils.py
+++ b/eox_hooks/utils.py
@@ -70,3 +70,52 @@ def _get_course(course_key):
     from xmodule.modulestore.django import modulestore  # pylint: disable=import-error,import-outside-toplevel
 
     return modulestore().get_course(course_key)
+
+
+def unflatten_dict(flat_dict, delimiter='.'):
+    """
+    Expands a flat dictionary with delimited keys into a nested dictionary structure.
+
+    This function iterates through keys containing a specific delimiter (default is '.')
+    and creates the corresponding nested dictionary tree. It is particularly useful
+    for converting flat configuration files or environment variables into structured
+    JSON-like objects.
+
+    Args:
+        flat_dict (dict): The dictionary with flat, delimited keys.
+        delimiter (str): The character used to separate nested levels. Defaults to '.'.
+
+    Returns:
+        dict: A deeply nested dictionary representing the original hierarchy.
+
+    Example:
+        >>> flat_data = {
+        ...     "base.footer.logo_url": "https://edunext.co",
+        ...     "base.footer.copy": "All rights reserved",
+        ...     "foo": "eduNEXT"
+        ... }
+        >>> unflatten_dict(flat_data)
+        {
+            'base': {
+                'footer': {
+                    'logo_url': 'https://edunext.co',
+                    'copy': 'All rights reserved'
+                }
+            },
+            'foo': 'eduNEXT'
+        }
+    """
+    unflattened = {}
+
+    for key, value in flat_dict.items():
+        parts = key.split(delimiter)
+        target = unflattened
+
+        # Traverse/create the path for all parts except the leaf
+        for part in parts[:-1]:
+            target = target.setdefault(part, {})
+
+        # Assign the final value to the leaf key
+        target[parts[-1]] = value
+
+    return unflattened

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 8.3.0
+current_version = 8.4.0
 commit = False
 tag = False
 


### PR DESCRIPTION
This PR introduces several improvements to the post_to_webhook_url action to make it more flexible when integrating with third-party services (like Accredible, Make, or custom APIs) that require specific headers or nested JSON structures.

## Key Changes

### 1. Custom HTTP Headers

Users can now define a `headers` object in their trigger settings. This is crucial for services requiring API Keys or Bearer tokens.

* **Example Config:** `"headers": {"Authorization": "Token secret_abc"}`

### 2. Data Unflattening (`unflatten_data`)

Many 3rd party services expect nested JSON rather than flat "dot-notated" strings. We've added a utility that transforms:
`{"user.email": "test@test.com"}`  `{"user": {"email": "test@test.com"}}`

### 3. Course Context Injection

By setting `use_course_information: true`, the webhook will now resolve and include the full `course` object in the context, even if the initial trigger only provided certificate data.

## Technical Details

* Added `unflatten_dict` to `utils.py` with support for custom delimiters.
* Refactored `get_certificate` to avoid code duplication in `actions.py`.
* Added defensive checks to ensure backward compatibility for triggers without the new settings.

## Testing Executed

* **Unit Tests**: Added `test_post_to_webhook_url_with_custom_headers` to verify header injection.
* **Utility Tests**: Added `test_unflatten_dict_default_delimiter` and `test_unflatten_dict_custom_delimiter` to ensure the recursion logic is sound.
* **Integration**: Verified that `unflatten_dict` correctly handles leaf-node assignment via `setdefault`.

## Testing instructions
**Environment Setup:**

- Ensure the eox-hooks plugin is installed.
- Configure a tenant or microsite with the following EOX_HOOKS_DEFINITIONS:

```json
"post_certificate_creation": {
        "action": "post_to_webhook_url",
        "config": {
            "fields": {
                "credential.recipient.id": "certificate.user.id",
                "credential.recipient.name": "certificate.user.pii.name",
                "credential.recipient.email": "certificate.user.pii.email",
                "credential.group_id": "course.number",
                "credential.issued_on": "metadata.time",
                "credential.custom_attributes.course_id": "course.id",
                "credential.custom_attributes.course_name": "course.name",
                "credential.custom_attributes.course_key": "certificate.course.course_key",
                "credential.custom_attributes.certificate_name": "certificate.name",
            },
            "send_certificate_data": false,
            "url": "https://api.accredible.com/v1/credentials",
            "use_course_information": true,
            "unflatten_data": true,
            "headers": {
                "Authorization": "Token ..."
            }
        },
        "fail_silently": false,
        "module": "eox_hooks.actions"
    }
```

**Manual Test:**

- Trigger the configured event (e.g., generate a certificate for a learner).

- Check the receiving end (e.g., Webhook.site) to verify that the incoming request contains both the Authorization and X-Custom-Header headers.

**Automated Tests:**

Run the updated unit tests:

```bash
make test-python
```

Confirm that test_post_to_webhook_url_with_custom_headers and test_post_to_webhook_url_without_headers_in_config pass successfully.

### Additional information
- Dependencies: This change does not depend on other repositories.
- Security: Headers are managed via tenant configuration, allowing for secure API Key management outside of the source code.
- Limitations: The payload format remains application/x-www-form-urlencoded by default to avoid breaking existing integrations.

### Checklist for Merge
- [ ] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits