### PR TITLE
chore: update integration test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tutor_version: ['<20.0.0', '<21.0.0', 'main']
+        tutor_version: ['<21.0.0', '<22.0.0', 'main']
     steps:
       - name: Run Integration Tests
-        uses: eduNEXT/integration-test-in-tutor@main
+        uses: eduNEXT/integration-test-in-tutor@v0.1.3
         with:
           tutor_version: ${{ matrix.tutor_version }}
           app_name: 'eox-hooks'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v8.3.1](https://github.com/eduNEXT/eox-theming/compare/v8.3.0...v8.3.1) - (2026-01-20)
+
+### Changed
+
+- Update Tutor integration-tests GitHub Action version to avoid integration test failures.
+
 ## [v8.3.0](https://github.com/eduNEXT/eox-hooks/compare/v8.2.0...v8.3.0) - (2025-10-13)
 
 ### Changed

--- a/eox_hooks/__init__.py
+++ b/eox_hooks/__init__.py
@@ -5,7 +5,7 @@ Init module for eox_hooks.
 
 import django.dispatch
 
-__version__ = '8.3.0'
+__version__ = '8.3.1'
 
 
 dummy_signal = django.dispatch.Signal()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 8.3.0
+current_version = 8.3.1
 commit = False
 tag = False
 


### PR DESCRIPTION
This pull request updates the project version to v8.3.1 and addresses integration test reliability by updating the GitHub Action used for Tutor integration tests. The main focus is on ensuring compatibility with newer Tutor versions and preventing test failures.

Version bump and changelog:

* Updated project version to `8.3.1` in `setup.cfg` and `eox_hooks/__init__.py`. [[1]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L2-R2) [[2]](diffhunk://#diff-d7096dd56289006f95666b3cdb54dde837cf67a0eae794d815c8ccfee71a4d4fL8-R8)
* Added a changelog entry for v8.3.1 describing the update to the integration test GitHub Action.

Integration test improvements:

* Updated the `tutor_version` test matrix in `.github/workflows/integration-test.yml` to cover newer Tutor versions and switched the integration test action to use `eduNEXT/integration-test-in-tutor@v0.1.3` for improved reliability.